### PR TITLE
Do not assume that "." is in "$PATH"

### DIFF
--- a/features/gradlew-support.feature
+++ b/features/gradlew-support.feature
@@ -6,22 +6,22 @@ Feature: Execute Key Bindings with gradlew
   Scenario: Run gradlew Build Without Daemon
     When I press "C-c C-g b"
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew build"
+    And Compilation command is "./gradlew build"
 
   Scenario: Run gradlew Test Without Daemon
     When I press "C-c C-g t"
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew test"
+    And Compilation command is "./gradlew test"
 
   Scenario: Run gradlew Build Command With Daemon
     When I press "C-c C-g C-d b"
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew build --daemon"
+    And Compilation command is "./gradlew build --daemon"
 
   Scenario: Run gradlew Test Command With Daemon
     When I press "C-c C-g C-d t"
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew test --daemon"
+    And Compilation command is "./gradlew test --daemon"
 
   Scenario: Run gradlew Single Test Without Daemon
     Given I start an action chain
@@ -29,7 +29,7 @@ Feature: Execute Key Bindings with gradlew
     And I type "MySpec"
     When I execute the action chain
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew test -Dtest.single=MySpec"
+    And Compilation command is "./gradlew test -Dtest.single=MySpec"
 
   Scenario: Run gradlew Single Test With Daemon
     Given I start an action chain
@@ -37,7 +37,7 @@ Feature: Execute Key Bindings with gradlew
     And I type "MySpec"
     When I execute the action chain
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew test -Dtest.single=MySpec --daemon"
+    And Compilation command is "./gradlew test -Dtest.single=MySpec --daemon"
 
   Scenario: Execute User Prompted Task(s) Without gradlew Daemon
     Given I start an action chain
@@ -45,7 +45,7 @@ Feature: Execute Key Bindings with gradlew
     And I type "clean build"
     When I execute the action chain
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew clean build"
+    And Compilation command is "./gradlew clean build"
 
   Scenario: Execute User Prompted Task(s) With gradlew Daemon
     Given I start an action chain
@@ -53,4 +53,4 @@ Feature: Execute Key Bindings with gradlew
     And I type "clean build"
     When I execute the action chain
     Then Compilation directory is "gradle-mode-root-path"
-    And Compilation command is "gradlew clean build --daemon"
+    And Compilation command is "./gradlew clean build --daemon"

--- a/gradle-mode.el
+++ b/gradle-mode.el
@@ -49,7 +49,7 @@ Absolute path, usually found with `executable-find'."
   :group 'gradle
   :type 'string)
 
-(defcustom gradle-gradlew-executable "gradlew"
+(defcustom gradle-gradlew-executable "./gradlew"
   "String representation of the gradlew executable."
   :group 'gradle
   :type 'string)

--- a/test/gradle-mode-test.el
+++ b/test/gradle-mode-test.el
@@ -44,15 +44,15 @@
     (should
      (equal
       (gradle-make-command "test -Dtest-single=MyTest --daemon")
-      "gradlew test -Dtest-single=MyTest --daemon"))
+      "./gradlew test -Dtest-single=MyTest --daemon"))
     (should
      (equal
       (gradle-make-command "build --daemon")
-      "gradlew build --daemon"))
+      "./gradlew build --daemon"))
     (should
      (equal
       (gradle-make-command "test")
-      "gradlew test"))))
+      "./gradlew test"))))
 
 ;; find the correct gradle project directory to run commands in
 


### PR DESCRIPTION
Putting `.` in `$PATH` creates certain security concerns, so many of us avoid doing that.  Without `.` in `$PATH`, running a `gradlew` script in the current directory requires an explicit relative path: `./gradlew`, not simply `gradlew`.