### PR TITLE
A little note cf. #4 to help people who browse list-packages

### DIFF
--- a/gradle-mode.el
+++ b/gradle-mode.el
@@ -28,6 +28,9 @@
 
 ;; Gradle integration into Emacs, through compile-mode.
 ;; see documentation on https://github.com/jacobono/emacs-gradle-mode
+;;
+;; If you are looking for syntax highlighting of .gradle files, try
+;; groovy-mode instead.
 
 ;;; Code:
 


### PR DESCRIPTION
since `Commentary` is shown when looking at this in list-packages (I have now installed this package twice looking for syntax highlighting 🙈 )